### PR TITLE
Fix product grid container structure

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,10 +3,9 @@ layout: layout.njk
 title: Home
 ---
 
-<img src="/img/shop_banner_buzco.gif" 
-     alt="Shop Now"  
+<img src="/img/shop_banner_buzco.gif"
+     alt="Shop Now"
      width="100px">
-</div>
 
 
 <div class="products-grid">
@@ -84,6 +83,7 @@ title: Home
     <p>{{ product.data.shopify_embed }}</p>
   </div>
 {% endfor %}
+</div>
 
   
 


### PR DESCRIPTION
## Summary
- remove an extra closing div after the hero image and close the products grid container after the product loop
- ensure the footer renders below the product grid by balancing the layout markup

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd800161b88326877e5f66572d93d0