### PR TITLE
Fix product template wrapper closing tags

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -42,43 +42,42 @@ title: Home
     <button class="btn-coming-soon" type="button" disabled aria-disabled="true">
   Coming Soon
     </button>
-</div>
-<style>
-  .btn-coming-soon {
-    /* colors */
-    --base: #009c6d;      /* ≈20% darker than #00c389 */
-    --highlight: #00c389; /* bevel highlight */
-    --shadow: #007a55;    /* bevel shadow */
+    <style>
+      .btn-coming-soon {
+        /* colors */
+        --base: #009c6d;      /* ≈20% darker than #00c389 */
+        --highlight: #00c389; /* bevel highlight */
+        --shadow: #007a55;    /* bevel shadow */
 
-    background: var(--base);
-    color: #000; /* black text */
-    font-family: "Times New Roman", Times, serif;
-    font-weight: 700;
-    font-size: 1rem;
-    letter-spacing: .02em;
+        background: var(--base);
+        color: #000; /* black text */
+        font-family: "Times New Roman", Times, serif;
+        font-weight: 700;
+        font-size: 1rem;
+        letter-spacing: .02em;
 
-    border-radius: 0;     /* sharp corners */
-    border-top: 4px solid var(--highlight);
-    border-left: 4px solid var(--highlight);
-    border-bottom: 4px solid var(--shadow);
-    border-right: 4px solid var(--shadow);
+        border-radius: 0;     /* sharp corners */
+        border-top: 4px solid var(--highlight);
+        border-left: 4px solid var(--highlight);
+        border-bottom: 4px solid var(--shadow);
+        border-right: 4px solid var(--shadow);
 
-    padding: 0.75rem 1.1rem;
-    line-height: 1;
-    display: inline-block;
+        padding: 0.75rem 1.1rem;
+        line-height: 1;
+        display: inline-block;
 
-    cursor: not-allowed;  /* communicates disabled */
-    pointer-events: none; /* truly non-clickable */
-    user-select: none;
-    /* crisp outer hairline for contrast on varied backgrounds */
-    box-shadow: 0 0 0 1px #005a3f inset;
-  }
+        cursor: not-allowed;  /* communicates disabled */
+        pointer-events: none; /* truly non-clickable */
+        user-select: none;
+        /* crisp outer hairline for contrast on varied backgrounds */
+        box-shadow: 0 0 0 1px #005a3f inset;
+      }
 
-  .btn-coming-soon:hover,
-  .btn-coming-soon:focus {
-    outline: none; /* no interaction states */
-  }
-</style>
+      .btn-coming-soon:hover,
+      .btn-coming-soon:focus {
+        outline: none; /* no interaction states */
+      }
+    </style>
 
     <p>{{ product.data.shopify_embed }}</p>
   </div>


### PR DESCRIPTION
## Summary
- keep the product template wrapper open through the Shopify embed paragraph inside the product loop
- ensure the button styles remain indented within the template so the wrapper closes only after the embed content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd8505b4d88326aeb43c115653ec51