### PR TITLE
Remove inline product image scripts

### DIFF
--- a/_includes/product-template.njk
+++ b/_includes/product-template.njk
@@ -5,22 +5,9 @@
 
 <div class="image-thumb">
   {% for image in images | slice(0, 4) %}
-    <img src="{{ image.image }}" onmouseover="updateImage(this)" {% if loop.index0 == 0 %}class="active"{% endif %}>
+    <img src="{{ image.image }}" {% if loop.index0 == 0 %}class="active"{% endif %}>
   {% endfor %}
 </div>
-
-<script>
-  function updateImage(ele) {
-    const product = ele.closest(".product-template");
-    const viewer = product.querySelector(".image-viewer img");
-    const thumbs = product.querySelectorAll(".image-thumb img");
-
-    viewer.src = ele.src;
-
-    thumbs.forEach(img => img.classList.remove("active"));
-    ele.classList.add("active");
-  }
-</script>
 
   <h2>{{ title }}</h2>
 

--- a/scripts.js
+++ b/scripts.js
@@ -1,12 +1,33 @@
-
-
-
-  document.querySelectorAll('.product-image').forEach(img => {
-    img.addEventListener('click', () => {
-      img.classList.toggle('zoomed');
-    });
+document.querySelectorAll('.product-image').forEach(img => {
+  img.addEventListener('click', () => {
+    img.classList.toggle('zoomed');
   });
-  
+});
 
+document.querySelectorAll('.product-template').forEach(product => {
+  const viewer = product.querySelector('.product-image');
+  const thumbnails = Array.from(product.querySelectorAll('.image-thumb img'));
 
+  if (!viewer || thumbnails.length === 0) {
+    return;
+  }
 
+  product.addEventListener(
+    'pointerover',
+    event => {
+      const target = event.target;
+
+      if (!(target instanceof HTMLElement) || !target.matches('.image-thumb img')) {
+        return;
+      }
+
+      if (viewer.src !== target.src) {
+        viewer.src = target.src;
+      }
+
+      thumbnails.forEach(img => {
+        img.classList.toggle('active', img === target);
+      });
+    }
+  );
+});

--- a/src/index.html
+++ b/src/index.html
@@ -14,27 +14,14 @@ title: Home
 {% for product in collections.products %}
   <div class="product-template">
     <div class="image-viewer">
-      <img src="{{ product.data.images[0].image }}" alt="{{ product.data.title }}">
+      <img src="{{ product.data.images[0].image }}" alt="{{ product.data.title }}" class="product-image">
     </div>
 
     <div class="image-thumb">
       {% for image in product.data.images | slice(0, 4) %}
-        <img src="{{ image.image }}" onmouseover="updateImage(this)" {% if loop.index0 == 0 %}class="active"{% endif %}>
+        <img src="{{ image.image }}" {% if loop.index0 == 0 %}class="active"{% endif %}>
       {% endfor %}
     </div>
-
-    <script>
-      function updateImage(ele) {
-        const product = ele.closest(".product-template");
-        const viewer = product.querySelector(".image-viewer img");
-        const thumbs = product.querySelectorAll(".image-thumb img");
-
-        viewer.src = ele.src;
-
-        thumbs.forEach(img => img.classList.remove("active"));
-        ele.classList.add("active");
-      }
-    </script>
 
     <h2>
       <a href="{{ product.url }}#souvenir">{{ product.data.title }}</a>


### PR DESCRIPTION
## Summary
- remove inline image swap scripts from product templates and standardize the viewer image hook
- centralize thumbnail swap behavior in scripts.js using a single pointer listener per product template

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cecbb07c088326b9be94b72f43f1d9