### PR TITLE
Move coming soon button styles to stylesheet

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -42,45 +42,8 @@ title: Home
     <p class="description">{{ product.data.description }}</p>
  
     <button class="btn-coming-soon" type="button" disabled aria-disabled="true">
-  Coming Soon
+      Coming Soon
     </button>
-
-<style>
-  .btn-coming-soon {
-    /* colors */
-    --base: #009c6d;      /* ≈20% darker than #00c389 */
-    --highlight: #00c389; /* bevel highlight */
-    --shadow: #007a55;    /* bevel shadow */
-
-    background: var(--base);
-    color: #000; /* black text */
-    font-family: "Times New Roman", Times, serif;
-    font-weight: 700;
-    font-size: 1rem;
-    letter-spacing: .02em;
-
-    border-radius: 0;     /* sharp corners */
-    border-top: 4px solid var(--highlight);
-    border-left: 4px solid var(--highlight);
-    border-bottom: 4px solid var(--shadow);
-    border-right: 4px solid var(--shadow);
-
-    padding: 0.75rem 1.1rem;
-    line-height: 1;
-    display: inline-block;
-
-    cursor: not-allowed;  /* communicates disabled */
-    pointer-events: none; /* truly non-clickable */
-    user-select: none;
-    /* crisp outer hairline for contrast on varied backgrounds */
-    box-shadow: 0 0 0 1px #005a3f inset;
-  }
-
-  .btn-coming-soon:hover,
-  .btn-coming-soon:focus {
-    outline: none; /* no interaction states */
-  }
-</style>
 
     <p>{{ product.data.shopify_embed }}</p>
   </div>

--- a/styles.css
+++ b/styles.css
@@ -300,6 +300,41 @@ footer {
 /* ====================== */
 /* === BUTTONS === */
 /* ====================== */
+.btn-coming-soon {
+  /* colors */
+  --base: #009c6d;      /* ≈20% darker than #00c389 */
+  --highlight: #00c389; /* bevel highlight */
+  --shadow: #007a55;    /* bevel shadow */
+
+  background: var(--base);
+  color: #000; /* black text */
+  font-family: "Times New Roman", Times, serif;
+  font-weight: 700;
+  font-size: 1rem;
+  letter-spacing: .02em;
+
+  border-radius: 0;     /* sharp corners */
+  border-top: 4px solid var(--highlight);
+  border-left: 4px solid var(--highlight);
+  border-bottom: 4px solid var(--shadow);
+  border-right: 4px solid var(--shadow);
+
+  padding: 0.75rem 1.1rem;
+  line-height: 1;
+  display: inline-block;
+
+  cursor: not-allowed;  /* communicates disabled */
+  pointer-events: none; /* truly non-clickable */
+  user-select: none;
+  /* crisp outer hairline for contrast on varied backgrounds */
+  box-shadow: 0 0 0 1px #005a3f inset;
+}
+
+.btn-coming-soon:hover,
+.btn-coming-soon:focus {
+  outline: none; /* no interaction states */
+}
+
 .size-btn,
 .buynow-btn {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- move the coming soon button styling from the product loop into the shared stylesheet so all button styles are centralized
- tidy the button markup so the global rule continues to render the same disabled state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cecbb7af84832685d264f3dd5c40e9