### PR TITLE
Fix thumbnail overflow in product template

### DIFF
--- a/_includes/product-template.njk
+++ b/_includes/product-template.njk
@@ -5,12 +5,14 @@
     {% endif %}
   </div>
 
-  <div class="image-thumb">
-    {% set limitedImages = (product.data.images | default([])) | slice(0, 4) %}
-    {% for image in limitedImages %}
-      <img src="{{ image.image }}" {% if loop.index0 == 0 %}class="active"{% endif %} loading="lazy">
-    {% endfor %}
-  </div>
+  {% set limitedImages = (product.data.images | default([])) | slice(0, 4) %}
+  {% if limitedImages | length %}
+    <div class="image-thumb thumbnail-row">
+      {% for image in limitedImages %}
+        <img src="{{ image.image }}" {% if loop.index0 == 0 %}class="active"{% endif %} loading="lazy">
+      {% endfor %}
+    </div>
+  {% endif %}
 
   <h2><a href="{{ product.url }}#souvenir">{{ product.data.title }}</a></h2>
   <p class="description">{{ product.data.description }}</p>

--- a/styles.css
+++ b/styles.css
@@ -149,41 +149,36 @@ footer a:hover {
 }
 
 /* Thumbnails: allow scroll instead of overflow */
-.thumbnail-row {
+.thumbnail-row,
+.image-thumb {
+  width: 100%;
   margin-top: 10px;
   display: flex;
   gap: 10px;
+  justify-content: center;
   overflow-x: auto;                /* allow scroll instead of overflow */
   overflow-y: hidden;              /* hide vertical overflow from hover */
   -webkit-overflow-scrolling: touch;
 }
 
-.thumbnail-row img {
-  flex: 0 0 auto;                  
+.thumbnail-row img,
+.image-thumb img {
+  flex: 0 0 auto;
   width: 60px;
   height: 60px;
+  padding: 5px;
   object-fit: cover;
   cursor: pointer;
   border: 1px solid var(--border-color);
+  opacity: 0.6;
   transition: transform 0.3s, border-color 0.3s;
   transform-origin: center;        /* scale grows evenly */
 }
 
-.thumbnail-row img:hover {
+.thumbnail-row img:hover,
+.image-thumb img:hover {
   border-color: var(--primary-color);
   transform: scale(1.25);          /* tamer scale so it stays neat */
-}
-
-.image-thumb {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-}
-.image-thumb img {
-  height: 60px;
-  padding: 5px;
-  border: 1px solid var(--border-color);
-  opacity: 0.6;
 }
 .active {
   opacity: 1 !important;


### PR DESCRIPTION
## Summary
- ensure the product template only renders the thumbnail strip when images exist and reuse the scrollable thumbnail-row styling
- consolidate thumbnail CSS so image-thumb elements gain overflow protection and consistent spacing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d816e63db48326954504fe5dd4f366