### PR TITLE
Enforce canonical URLs and add redirect rules

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -7,6 +7,7 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy("admin");
   eleventyConfig.addPassthroughCopy("robots.txt");
   eleventyConfig.addPassthroughCopy("sitemap.xml");
+  eleventyConfig.addPassthroughCopy("_redirects");
 
   eleventyConfig.addNunjucksFilter("date", function(dateObj, format = "yyyy-MM-dd") {
     if(typeof dateObj === "string") {

--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -11,7 +11,19 @@
   <!-- Open Graph / Social Media Sharing -->
   <meta property="og:title" content="Buzco — Souvenirs for Gr8 Success">
   <meta property="og:description" content="Modern Souvenir Shop. Erradicating the fear of looking stupid with gr8 success.">
-  <meta property="og:url" content="https://www.gr8success.xyz">
+  {% set canonicalPath = page.url | default('/') %}
+  {% if canonicalPath == '/index/' or canonicalPath == '/index.html' %}
+    {% set canonicalPath = '/' %}
+  {% endif %}
+  {% if canonicalPath == '/' %}
+    {% set canonicalUrl = 'https://www.gr8success.xyz/' %}
+  {% else %}
+    {% set canonicalUrl = 'https://www.gr8success.xyz' ~ canonicalPath %}
+  {% endif %}
+
+  <link rel="canonical" href="{{ canonicalUrl }}">
+
+  <meta property="og:url" content="{{ canonicalUrl }}">
   <meta property="og:type" content="website">
 
   <link rel="icon" href="/img/favicon.webp">
@@ -30,7 +42,7 @@
   </marquee>
 
 
-  <a href="/index/">
+  <a href="/">
     <img src="/img/rotating_logo_buzco.gif" alt="BuzcO" class="brand-logo">
   </a>
 

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,4 @@
+http://gr8success.xyz/* https://www.gr8success.xyz/:splat 301!
+http://www.gr8success.xyz/* https://www.gr8success.xyz/:splat 301!
+https://gr8success.xyz/* https://www.gr8success.xyz/:splat 301!
+/index.html / 301!


### PR DESCRIPTION
## Summary
- compute canonical URLs in the shared layout and point the home link to the root path
- add Netlify redirect rules to force https://www.gr8success.xyz with HTTPS and remove index.html duplicates
- ensure Eleventy copies the redirect configuration during builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ef8b8a3d148326ad7593754cb84240